### PR TITLE
Fixing positional argument error in yaml.load()

### DIFF
--- a/sloop/datasets/osm_scripts/parse_osm_mapping.py
+++ b/sloop/datasets/osm_scripts/parse_osm_mapping.py
@@ -3,7 +3,7 @@ import yaml
 
 def parse_json(js):
     data = json.dumps(js['elements'])
-    y = yaml.load(data)
+    y = yaml.load(data, Loader=yaml.Loader)
     return y
 
 nodes = {}

--- a/sloop/oopomdp/experiments/lang_result.py
+++ b/sloop/oopomdp/experiments/lang_result.py
@@ -25,13 +25,13 @@ class LangResult(YamlResult):
         # Collect both language as well as reward info and states info
         trial_path = os.path.dirname(path)
         with open(os.path.join(trial_path, RewardsResult.FILENAME())) as f:
-            rewards = yaml.load(f)
+            rewards = yaml.load(f, Loader=yaml.Loader)
         # Collect the states info
         with open(os.path.join(trial_path, StatesResult.FILENAME()), "rb") as f:
             states = pickle.load(f)
         # Collect the pickle file
         with open(path) as f:
-            langres = yaml.load(f)
+            langres = yaml.load(f, Loader=yaml.Loader)
         return (langres, rewards, states)
 
 
@@ -123,7 +123,7 @@ class LangResult(YamlResult):
   #          path = path[:-1]
 #        exp_path = os.path.dirname(path)
         with open(os.path.join(path, "good_foref_predictions.yaml")) as f:
-            good_forefs = yaml.load(f)
+            good_forefs = yaml.load(f, Loader=yaml.Loader)
         cls.do_it(gathered_results, path)
         print("--goood---")
         cls.do_it(gathered_results, path, good_forefs=good_forefs)


### PR DESCRIPTION
While running `python gather_results.py` in `sloop/results/all-joint-sloop` it throws the error - 

> TypeError: load() missing 1 required positional argument: 'Loader'

This change fix that issue